### PR TITLE
Speed Up Feed Rendering

### DIFF
--- a/gohike-api/models/authorization.js
+++ b/gohike-api/models/authorization.js
@@ -75,7 +75,8 @@ class Authorization {
       sessionToken: loginUser.getSessionToken(),
       firstName: loginUser.get("firstName"),
       lastName: loginUser.get("lastName"),
-      location: loginUser.get("location")
+      location: loginUser.get("location"),
+      posts: loginUser.get("feed")
     };
   }
 

--- a/gohike-api/models/authorization.js
+++ b/gohike-api/models/authorization.js
@@ -37,7 +37,8 @@ class Authorization {
     age,
     username,
     password,
-    email
+    email,
+    location
   ) {
     // Create empty Parse _User object
     let user = new Parse.User();
@@ -49,6 +50,7 @@ class Authorization {
     user.set("username", username);
     user.set("password", password);
     user.set("email", email);
+    user.set("location", location);
     user.set("saved", []);
     user.set("completed", []);
     user.set("posts", []);

--- a/gohike-api/models/authorization.js
+++ b/gohike-api/models/authorization.js
@@ -75,6 +75,7 @@ class Authorization {
       sessionToken: loginUser.getSessionToken(),
       firstName: loginUser.get("firstName"),
       lastName: loginUser.get("lastName"),
+      location: loginUser.get("location")
     };
   }
 

--- a/gohike-api/models/authorization.js
+++ b/gohike-api/models/authorization.js
@@ -86,11 +86,20 @@ class Authorization {
    * @param {String} sessionToken Corresponds to the session to destroy
    * @returns {Object} Contains message indicating successful logout
    */
-  static async logoutUser(sessionToken) {
+  static async logoutUser(sessionToken, feed) {
     // Get session by session token
     let query = new Parse.Query("_Session");
     query.equalTo("sessionToken", sessionToken);
     let sessionToDestroy = await query.first({ useMasterKey: true });
+
+    // Get User object from object Id
+    let query2 = new Parse.Query("_User");
+    query2.equalTo("objectId", sessionToDestroy.get("user").id);
+    let user = await query.first({ useMasterKey: true });
+
+    // Reset user's feed
+    user.set("feed", feed)
+    await user.save(null, { useMasterKey: true })
 
     // Destroy session
     sessionToDestroy.destroy({ useMasterKey: true });

--- a/gohike-api/models/posts.js
+++ b/gohike-api/models/posts.js
@@ -68,6 +68,7 @@ class Posts {
     let posts = [{ id: post.id, lat: trail.get("latitude"), 
     lng: trail.get('longitude')}]
     if (userObject.get("posts") != null && userObject.get("posts") != undefined) {
+      console.log(userObject.get("posts"))
       posts = posts.concat(userObject.get("posts"))
     }
 

--- a/gohike-api/models/posts.js
+++ b/gohike-api/models/posts.js
@@ -124,27 +124,6 @@ class Posts {
   }
 
   /**
-   * Gets all posts in the Parse database
-   *
-   * @returns @returns {Array<Number>} Contains the id's of all posts in the
-   * Parse database
-   */
-  static async getAllPosts() {
-    // Get all Post objects
-    let query = new Parse.Query("Post");
-    query.descending("createdAt");
-    let posts = await query.find({ useMasterKey: true });
-
-    // Add all post id's to res array
-    let res = [];
-    for (let i = 0; i < posts.length; i++) {
-      res.push(posts[i].id);
-    }
-
-    return res;
-  }
-
-  /**
    * Queries Parse for information on a specific post
    *
    * @param {Number} postId Corresponds to the post to return

--- a/gohike-api/models/posts.js
+++ b/gohike-api/models/posts.js
@@ -87,7 +87,8 @@ class Posts {
         let friend = await query4.first({ useMasterKey: true });
 
         // Add post to friend's feed array
-        let feed = [post.id]
+        let feed = [{ id: post.id, lat: trail.get("latitude"), 
+        lng: trail.get('longitude')}]
         if (friend.get("feed") != null && friend.get("feed") != undefined) {
           feed = feed.concat(friend.get("feed"))
         }
@@ -104,41 +105,22 @@ class Posts {
   /**
    * Gets all posts made by the current user's friends
    *
-   * @param {String} sessionToken Corresponds to session of the current user
-   * @returns {Array<Number>} Contains the id's of all posts made by the
-   * current user's friends
+   * @param {string} username Corresponds to username of the current user
+   * @returns {Array<{ id: number, lat: number, lng: number }>} Contains the 
+   * id and location of all posts made by the current user's friends
    */
-  static async getFriendPosts(sessionToken) {
-    // Get User pointer from sessionToken
-    let query = new Parse.Query("_Session");
-    query.equalTo("sessionToken", sessionToken);
-    let session = await query.first({ useMasterKey: true });
-    let userId = session.get("user").id;
+  static async getFriendPosts(username) {
+    // Get User from username
+    let query = new Parse.Query("_User");
+    query.equalTo("username", username);
+    let user = await query.first({ useMasterKey: true });
 
-    // Get User object's friends from user pointer
-    let query4 = new Parse.Query("_User");
-    query4.equalTo("objectId", userId);
-    let user = await query4.first({ useMasterKey: true });
-    let friends = user.get("friends");
-
-    // Return empty array if user has no friends
-    if (friends == undefined || friends.length == 0) {
-      return [];
+    // Return user's feed array
+    if (user.get("feed") == undefined || user.get("feed") == null) {
+      return []
+    } else {
+      return user.get("feed")
     }
-
-    // Add post id to posts array if it is from the user's friend
-    let posts = [];
-    for (let i = 0; i < friends.length; i++) {
-      let query3 = new Parse.Query("_User");
-      query3.equalTo("username", friends[i]);
-      let friend = await query3.first({ useMasterKey: true });
-
-      if (friend.get("posts") != null && friend.get("posts") != undefined) {
-        posts = posts.concat(friend.get("posts"));
-      }
-    }
-
-    return posts;
   }
 
   /**

--- a/gohike-api/models/posts.js
+++ b/gohike-api/models/posts.js
@@ -21,7 +21,7 @@ class Posts {
   constructor() {
     this.super();
   }
-
+  
   /**
    * Creates a new Post object and saves new post to Parse
    *

--- a/gohike-api/models/posts.js
+++ b/gohike-api/models/posts.js
@@ -3,7 +3,6 @@
  * to implement a Posts class and is called by the the Posts routing methods.
  */
 require("dotenv").config();
-const pq = require("./pq");
 var Parse = require("parse/node");
 Parse.initialize(
   process.env.APP_ID,

--- a/gohike-api/models/pq.js
+++ b/gohike-api/models/pq.js
@@ -14,6 +14,23 @@ class pq {
   }
 
   /**
+   * 
+   * @param {Array<{ id: string, lat: number, lng: number, priority: 
+   * number }>} arr Post id's for a user's feed in unsorted order
+   * @param {*} userLat Latitude of current user
+   * @param {*} userLng Longitude of current user
+   * @returns 
+   */
+  static create(arr, userLat, userLng) {
+    let pq = []
+    for (let i = 0; i < arr.length; i++) {
+      pq = this.insert(pq, arr[i].id, arr[i].lat, arr[i].lng, userLat, userLng)
+    }
+
+    return pq
+  }
+
+  /**
    * Converts a number in degrees to radians
    *
    * @param {number} deg
@@ -63,11 +80,11 @@ class pq {
   /**
    * Shifts node up to maintain heap property of priority queue
    *
-   * @param {Array<{ postId: string, priority: number }} arr Priority queue to
-   * insert into
+   * @param {Array<{ id: string, lat: number, lng: number, priority: 
+   * number }>} arr Priority queue to insert into
    * @param {number} index Index of current node
-   * @returns {Array<{ postId: string, priority: number }} Priority queue with
-   * newly inserted post
+   * @returns {Array<{ id: string, lat: number, lng: number, priority: 
+   * number }>} Priority queue with newly inserted post
    */
   static shiftUp(arr, index) {
     while (
@@ -75,9 +92,9 @@ class pq {
       arr[this.parentIndex(index)].priority < arr[index].priority
     ) {
       // Swap parent and current node
-      var temp = arr[i];
-      arr[i] = arr[j];
-      arr[j] = temp;
+      var temp = arr[index];
+      arr[index] = arr[this.parentIndex(index)];
+      arr[this.parentIndex(index)] = temp;
 
       // Update index to parent of index
       index = this.parentIndex(index);
@@ -88,32 +105,35 @@ class pq {
 
   /**
    *
-   * @param {Array<{ postId: string, priority: number }>} arr Priority queue
+   * @param {Array<{ id: string, lat: number, lng: number, priority: 
+   * number }>} arr Priority queue
    * containing post id's from friends of the user
    * @param {string} postId Of the post to insert
-   * @param {number} postLng Longitude of the hike the post to insert is about
    * @param {number} postLat Latitude of the hike the post to insert is about
-   * @param {number} userLng Longitude of the user of which the pq we are
-   * inserting into is from
+   * @param {number} postLng Longitude of the hike the post to insert is about
    * @param {number} userLat Latitude of the user of which the pq we are
    * inserting into is from
-   * @returns {Array<{ postId: string, priority: number }} Priority queue with
-   * newly inserted post
+   * @param {number} userLng Longitude of the user of which the pq we are
+   * inserting into is from
+   * @returns {Array<{ id: string, lat: number, lng: number, priority: 
+   * number }>} Priority queue with newly inserted post
    */
-  static insert(arr, postId, postLng, postLat, userLng, userLat) {
+  static insert(arr, postId, postLat, postLng, userLat, userLng) {
     // let posts about hikes closest to the user have higher priority
-    let priority = this.getDistanceFromLatLonInKm(
-      postLng,
+    let priority = -1 * this.getDistanceFromLatLonInKm(
       postLat,
-      userLng,
-      userLat
+      postLng,
+      userLat,
+      userLng
     );
 
     // Insert post at the end and shift up accordingly
-    arr.push({ postId, priority });
+    arr.push({ id: postId, priority, lat: postLat, lng: postLng });
     let insertedPq = this.shiftUp(arr, arr.length - 1);
 
     // Return new pq
     return insertedPq;
   }
 }
+
+export {pq}

--- a/gohike-api/models/pq.js
+++ b/gohike-api/models/pq.js
@@ -1,0 +1,119 @@
+/**
+ * @fileoverview This file implements methods for a priority queue elements to
+ * insert user's posts for their feed with high priority given to posts about
+ * hikes close to the user.
+ */
+
+/**
+ * This class handles the creating priority queue elements and inserting into a
+ * priority queue.
+ */
+class pq {
+  constructor() {
+    this.super();
+  }
+
+  /**
+   * Converts a number in degrees to radians
+   *
+   * @param {number} deg
+   * @returns {number} Result in radians
+   */
+  static deg2rad(deg) {
+    return deg * (Math.PI / 180);
+  }
+
+  /**
+   * Gets distance in kilometers between two points given by their lat and lng
+   *
+   * @param {number} lat1 Latitude of first point
+   * @param {number} lon1 Longitude of first point
+   * @param {number} lat2 Latitude of second point
+   * @param {number} lon2 Longitude of second point
+   * @returns {number} Distance in kilometers
+   */
+  static getDistanceFromLatLonInKm(lat1, lon1, lat2, lon2) {
+    // Radius of the earth in km
+    var R = 6371;
+    // deg2rad below
+    var dLat = this.deg2rad(lat2 - lat1);
+    var dLon = this.deg2rad(lon2 - lon1);
+    var a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(this.deg2rad(lat1)) *
+        Math.cos(this.deg2rad(lat2)) *
+        Math.sin(dLon / 2) *
+        Math.sin(dLon / 2);
+    var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    // Distance in km
+    var d = R * c;
+    return d;
+  }
+
+  /**
+   * Get the index of the parent of a child node
+   *
+   * @param {number} index Index of child node
+   * @returns {number} Index of parent node
+   */
+  static parentIndex(index) {
+    return parseInt((index - 1) / 2);
+  }
+
+  /**
+   * Shifts node up to maintain heap property of priority queue
+   *
+   * @param {Array<{ postId: string, priority: number }} arr Priority queue to
+   * insert into
+   * @param {number} index Index of current node
+   * @returns {Array<{ postId: string, priority: number }} Priority queue with
+   * newly inserted post
+   */
+  static shiftUp(arr, index) {
+    while (
+      index >= 0 &&
+      arr[this.parentIndex(index)].priority < arr[index].priority
+    ) {
+      // Swap parent and current node
+      var temp = arr[i];
+      arr[i] = arr[j];
+      arr[j] = temp;
+
+      // Update index to parent of index
+      index = this.parentIndex(index);
+    }
+
+    return arr;
+  }
+
+  /**
+   *
+   * @param {Array<{ postId: string, priority: number }>} arr Priority queue
+   * containing post id's from friends of the user
+   * @param {string} postId Of the post to insert
+   * @param {number} postLng Longitude of the hike the post to insert is about
+   * @param {number} postLat Latitude of the hike the post to insert is about
+   * @param {number} userLng Longitude of the user of which the pq we are
+   * inserting into is from
+   * @param {number} userLat Latitude of the user of which the pq we are
+   * inserting into is from
+   * @returns {Array<{ postId: string, priority: number }} Priority queue with
+   * newly inserted post
+   */
+  static insert(arr, postId, postLng, postLat, userLng, userLat) {
+    // let posts about hikes closest to the user have higher priority
+    let priority = this.getDistanceFromLatLonInKm(
+      postLng,
+      postLat,
+      userLng,
+      userLat
+    );
+
+    // Insert post at the end and shift up accordingly
+    arr.push({ postId, priority });
+    let insertedPq = this.shiftUp(arr, arr.length - 1);
+
+    // Return new pq
+    return insertedPq;
+  }
+}

--- a/gohike-api/models/pqservice.js
+++ b/gohike-api/models/pqservice.js
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview This file implements methods for a priority queue elements to
+ * insert user's posts for their feed with high priority given to posts about
+ * hikes close to the user.
+ */
+
+/**
+ * This class handles the creating priority queue elements and inserting into a
+ * priority queue.
+ */
+class pq {
+  constructor() {
+    this.super();
+  }
+
+  /**
+   * 
+   * @param {Array<{ id: string, lat: number, lng: number, priority: 
+   * number }>} arr Post id's for a user's feed in unsorted order
+   * @param {*} userLat Latitude of current user
+   * @param {*} userLng Longitude of current user
+   * @returns 
+   */
+  static create(arr, userLat, userLng) {
+    let pq = []
+    for (let i = 0; i < arr.length; i++) {
+      pq = this.insert(pq, arr[i].id, arr[i].lat, arr[i].lng, userLat, userLng)
+    }
+
+    return pq
+  }
+
+  /**
+   * Converts a number in degrees to radians
+   *
+   * @param {number} deg
+   * @returns {number} Result in radians
+   */
+  static deg2rad(deg) {
+    return deg * (Math.PI / 180);
+  }
+
+  /**
+   * Gets distance in kilometers between two points given by their lat and lng
+   *
+   * @param {number} lat1 Latitude of first point
+   * @param {number} lon1 Longitude of first point
+   * @param {number} lat2 Latitude of second point
+   * @param {number} lon2 Longitude of second point
+   * @returns {number} Distance in kilometers
+   */
+  static getDistanceFromLatLonInKm(lat1, lon1, lat2, lon2) {
+    // Radius of the earth in km
+    var R = 6371;
+    // deg2rad below
+    var dLat = this.deg2rad(lat2 - lat1);
+    var dLon = this.deg2rad(lon2 - lon1);
+    var a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(this.deg2rad(lat1)) *
+        Math.cos(this.deg2rad(lat2)) *
+        Math.sin(dLon / 2) *
+        Math.sin(dLon / 2);
+    var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    // Distance in km
+    var d = R * c;
+    return d;
+  }
+
+  /**
+   * Get the index of the parent of a child node
+   *
+   * @param {number} index Index of child node
+   * @returns {number} Index of parent node
+   */
+  static parentIndex(index) {
+    return parseInt((index - 1) / 2);
+  }
+
+  /**
+   * Shifts node up to maintain heap property of priority queue
+   *
+   * @param {Array<{ id: string, lat: number, lng: number, priority: 
+   * number }>} arr Priority queue to insert into
+   * @param {number} index Index of current node
+   * @returns {Array<{ id: string, lat: number, lng: number, priority: 
+   * number }>} Priority queue with newly inserted post
+   */
+  static shiftUp(arr, index) {
+    while (
+      index >= 0 &&
+      arr[this.parentIndex(index)].priority < arr[index].priority
+    ) {
+      // Swap parent and current node
+      var temp = arr[index];
+      arr[index] = arr[this.parentIndex(index)];
+      arr[this.parentIndex(index)] = temp;
+
+      // Update index to parent of index
+      index = this.parentIndex(index);
+    }
+
+    return arr;
+  }
+
+  /**
+   *
+   * @param {Array<{ id: string, lat: number, lng: number, priority: 
+   * number }>} arr Priority queue
+   * containing post id's from friends of the user
+   * @param {string} postId Of the post to insert
+   * @param {number} postLat Latitude of the hike the post to insert is about
+   * @param {number} postLng Longitude of the hike the post to insert is about
+   * @param {number} userLat Latitude of the user of which the pq we are
+   * inserting into is from
+   * @param {number} userLng Longitude of the user of which the pq we are
+   * inserting into is from
+   * @returns {Array<{ id: string, lat: number, lng: number, priority: 
+   * number }>} Priority queue with newly inserted post
+   */
+  static insert(arr, postId, postLat, postLng, userLat, userLng) {
+    // let posts about hikes closest to the user have higher priority
+    let priority = -1 * this.getDistanceFromLatLonInKm(
+      postLat,
+      postLng,
+      userLat,
+      userLng
+    );
+
+    // Insert post at the end and shift up accordingly
+    arr.push({ id: postId, priority, lat: postLat, lng: postLng });
+    let insertedPq = this.shiftUp(arr, arr.length - 1);
+
+    // Return new pq
+    return insertedPq;
+  }
+}
+
+module.exports = pq

--- a/gohike-api/models/user.js
+++ b/gohike-api/models/user.js
@@ -563,6 +563,26 @@ class User {
 
     return res;
   }
+
+  /**
+   * Updated a user's location
+   * 
+   * @param {number} lat Of the current user
+   * @param {number} lng Of the current user
+   * @param {string} username Of the current user
+   * @returns {string} Message to indicate successful update of location
+   */
+  static async updateLocation(lat, lng, username) {
+    // Get User object from username
+    let query = new Parse.Query("_User");
+    query.equalTo("username", username);
+    let user = await query.first({ useMasterKey: true });
+
+    // Set location
+    user.set("location", { lat, lng })
+    await user.save(null, { useMasterKey: true });
+    return "Updated user location"
+  }
 }
 
 

--- a/gohike-api/models/user.js
+++ b/gohike-api/models/user.js
@@ -211,7 +211,7 @@ class User {
    * Get the posts made by a user
    *
    * @param {string} sessionToken Corresponds to the current user
-   * @returns {Array<{ id: number, lat: number, lng: number>} Contains id and 
+   * @returns {Array<{ id: number, lat: number, lng: number>}} Contains id and 
    * location of posts created by current user
    */
   static async getUserPosts(username) {

--- a/gohike-api/models/user.js
+++ b/gohike-api/models/user.js
@@ -565,4 +565,5 @@ class User {
   }
 }
 
+
 module.exports = User;

--- a/gohike-api/models/user.js
+++ b/gohike-api/models/user.js
@@ -210,34 +210,21 @@ class User {
   /**
    * Get the posts made by a user
    *
-   * @param {String} sessionToken Corresponds to the current user
-   * @returns {Array<Number>} Contains id's of posts created by current user
+   * @param {string} sessionToken Corresponds to the current user
+   * @returns {Array<{ id: number, lat: number, lng: number>} Contains id and 
+   * location of posts created by current user
    */
-  static async getUserPosts(sessionToken) {
-    // Get User id from sessionToken
-    let query = new Parse.Query("_Session");
-    query.equalTo("sessionToken", sessionToken);
-    let session = await query.first({ useMasterKey: true });
-    let userId = session.get("user").id;
+  static async getUserPosts(username) {
+    // Get User from username
+    let query = new Parse.Query("_User");
+    query.equalTo("username", username);
+    let user = await query.first({ useMasterKey: true });
 
-    // Get user info
-    let query2 = new Parse.Query("_User");
-    query2.equalTo("objectId", userId);
-    let user = await query2.first({ useMasterKey: true });
-
-    // Get all Post objects
-    let query3 = new Parse.Query("Post");
-    let posts = await query3.find({ useMasterKey: true });
-
-    // Create array with necessary info for each post
-    let res = [];
-    for (let i = 0; i < posts.length; i++) {
-      if (posts[i].get("user").id == userId) {
-        res.push(posts[i].id);
-      }
+    if (user.get("posts") == undefined || user.get("posts") == null) {
+      return []
+    } else {
+      return user.get("posts")
     }
-
-    return res;
   }
 
   /**
@@ -299,35 +286,6 @@ class User {
     query.equalTo("username", username);
     let user = await query.first({ useMasterKey: true });
     return user;
-  }
-
-  /**
-   * Gets the posts made by a specified user
-   *
-   * @param {String} username Corresponds to the user whose posts are to get
-   * @returns {Array<Number>} Contains id's of the posts created by
-   * corresponding user
-   */
-  static async getViewUserPosts(username) {
-    // Get User info from username
-    let query = new Parse.Query("_User");
-    query.equalTo("username", username);
-    let user = await query.first({ useMasterKey: true });
-    let userId = user.id;
-
-    // Get all Post objects
-    let query2 = new Parse.Query("Post");
-    let posts = await query2.find({ useMasterKey: true });
-
-    // Create array with necessary info for each post
-    let res = [];
-    for (let i = 0; i < posts.length; i++) {
-      if (posts[i].get("user").id == userId) {
-        res.push(posts[i].id);
-      }
-    }
-
-    return res;
   }
 
   /**

--- a/gohike-api/routes/authorization.js
+++ b/gohike-api/routes/authorization.js
@@ -60,7 +60,8 @@ router.post("/login", async (req, res) => {
         sessionToken: loginUser.sessionToken,
         firstName: loginUser.firstName,
         lastName: loginUser.lastName,
-        location: loginUser.location
+        location: loginUser.location,
+        posts: loginUser.posts
       });
   } catch {
     res.status(400).json({ msg: "Failed to login user" });

--- a/gohike-api/routes/authorization.js
+++ b/gohike-api/routes/authorization.js
@@ -60,6 +60,7 @@ router.post("/login", async (req, res) => {
         sessionToken: loginUser.sessionToken,
         firstName: loginUser.firstName,
         lastName: loginUser.lastName,
+        location: loginUser.location
       });
   } catch {
     res.status(400).json({ msg: "Failed to login user" });

--- a/gohike-api/routes/authorization.js
+++ b/gohike-api/routes/authorization.js
@@ -20,6 +20,7 @@ router.post("/register", async (req, res) => {
   let username = infoUser.username;
   let password = infoUser.password;
   let email = infoUser.email;
+  let location = infoUser.location
 
   // Creates new user by calling Authorization methods
   try {
@@ -29,7 +30,8 @@ router.post("/register", async (req, res) => {
       age,
       username,
       password,
-      email
+      email,
+      location
     );
     res
       .status(201)

--- a/gohike-api/routes/authorization.js
+++ b/gohike-api/routes/authorization.js
@@ -75,8 +75,10 @@ router.post("/logout", async (req, res) => {
   try {
     // Gets session token in order to destroy corresponding session
     let sessionToken = req.body.sessionToken;
+    // Get feed to update user's Parse data
+    let feed = req.body.feed;
     // Destroys session by calling Authorization methods
-    let logoutUser = await Authorization.logoutUser(sessionToken);
+    let logoutUser = await Authorization.logoutUser(sessionToken, feed);
 
     res.status(201).json({ msg: logoutUser.msg });
   } catch {

--- a/gohike-api/routes/posts.js
+++ b/gohike-api/routes/posts.js
@@ -63,13 +63,14 @@ router.get("/likes", async (req, res) => {
  * Get request for getting posts from friends of the current user based on their
  * session token
  */
-router.get("/friends/:sessionToken", async (req, res) => {
+router.get("/friends/:username", async (req, res) => {
   try {
-    let sessionToken = req.params.sessionToken;
+    let username = req.params.username;
     // Gets likes array by calling Posts method
-    let posts = await Posts.getFriendPosts(sessionToken);
+    let posts = await Posts.getFriendPosts(username);
     res.status(201).json({ posts });
-  } catch {
+  } catch (err) {
+    console.log(err)
     res.status(400).json({ msg: "Failed to get friends' posts" });
   }
 });

--- a/gohike-api/routes/posts.js
+++ b/gohike-api/routes/posts.js
@@ -31,19 +31,6 @@ router.post("/create", async (req, res) => {
 });
 
 /**
- * Get request for getting all posts in the Parse database
- */
-router.get("/", async (req, res) => {
-  try {
-    // Gets all posts by calling Posts method
-    let posts = await Posts.getAllPosts();
-    res.status(201).json({ posts });
-  } catch {
-    res.status(400).json({ msg: "Failed to get posts" });
-  }
-});
-
-/**
  * Get request for getting the likes array of a post based on its postId
  */
 router.get("/likes", async (req, res) => {

--- a/gohike-api/routes/posts.js
+++ b/gohike-api/routes/posts.js
@@ -1,5 +1,7 @@
 /**
- * @fileoverview This file contains the Posts routing methods for the GoHike app API. It handles creation of and interaction with posts by calling on an instance of the Posts class in the models directory.
+ * @fileoverview This file contains the Posts routing methods for the GoHike 
+ * app API. It handles creation of and interaction with posts by calling on an 
+ * instance of the Posts class in the models directory.
  */
 const express = require("express");
 const router = express.Router();

--- a/gohike-api/routes/posts.js
+++ b/gohike-api/routes/posts.js
@@ -31,6 +31,23 @@ router.post("/create", async (req, res) => {
 });
 
 /**
+ * Put request for writing a newly created to post to the post creator's 
+ * friends' feeds
+ */
+router.put("/write/:username/:hikeId/:postId", async (req, res) => {
+  try {
+    // Get correct params
+    let username = req.params.username
+    let hikeId = parseInt(req.params.hikeId)
+    let postId = req.params.postId
+    let msg = await Posts.writePost(username, hikeId, postId)
+    res.status(201).json({ msg });
+  } catch (err) {
+    res.status(400).json({ msg: "Failed to write post" });
+  }
+})
+
+/**
  * Get request for getting all posts in the Parse database
  */
 router.get("/", async (req, res) => {

--- a/gohike-api/routes/posts.js
+++ b/gohike-api/routes/posts.js
@@ -31,23 +31,6 @@ router.post("/create", async (req, res) => {
 });
 
 /**
- * Put request for writing a newly created to post to the post creator's 
- * friends' feeds
- */
-router.put("/write/:username/:hikeId/:postId", async (req, res) => {
-  try {
-    // Get correct params
-    let username = req.params.username
-    let hikeId = parseInt(req.params.hikeId)
-    let postId = req.params.postId
-    let msg = await Posts.writePost(username, hikeId, postId)
-    res.status(201).json({ msg });
-  } catch (err) {
-    res.status(400).json({ msg: "Failed to write post" });
-  }
-})
-
-/**
  * Get request for getting all posts in the Parse database
  */
 router.get("/", async (req, res) => {

--- a/gohike-api/routes/user.js
+++ b/gohike-api/routes/user.js
@@ -289,7 +289,7 @@ router.put("/update-location", async (req, res) => {
     
     // Update location by calling User method
     let updated = await User.updateLocation(lat, lng, username)
-    res.status(201).json({ msg: updated });
+    res.status(201).json({ location: updated.location, posts: updated.posts });
   } catch (err) {
     res.status(400).json({ msg: "Failed to update location" });
   }

--- a/gohike-api/routes/user.js
+++ b/gohike-api/routes/user.js
@@ -73,11 +73,11 @@ router.get("/:sessionToken", async (req, res) => {
  * Get request for getting the id's of posts made by the current user based on
  * their session token stored in local storage
  */
-router.get("/posts/:sessionToken", async (req, res) => {
+router.get("/posts/:username", async (req, res) => {
   try {
-    const sessionToken = req.params.sessionToken;
+    const username = req.params.username;
     // Gets current user's posts by calling User method
-    let posts = await User.getUserPosts(sessionToken);
+    let posts = await User.getUserPosts(username);
     res.status(201).json({ posts });
   } catch (err) {
     console.log(err);
@@ -143,7 +143,7 @@ router.get("/view/posts/:username", async (req, res) => {
   try {
     const username = req.params.username;
     // Gets post id's by calling User method
-    let posts = await User.getViewUserPosts(username);
+    let posts = await User.getUserPosts(username);
     res.status(201).json({ posts });
   } catch {
     res.status(400).json({ msg: "Could not retrieve user posts." });

--- a/gohike-api/routes/user.js
+++ b/gohike-api/routes/user.js
@@ -277,4 +277,22 @@ router.put("/uncomplete", async (req, res) => {
   }
 });
 
+/**
+ * Put request to update a user's last location
+ */
+router.put("/update-location", async (req, res) => {
+  try {
+    // Gets location of current user
+    let lat = req.body.lat
+    let lng = req.body.lng
+    let username = req.body.username
+    
+    // Update location by calling User method
+    let updated = await User.updateLocation(lat, lng, username)
+    res.status(201).json({ msg: updated });
+  } catch (err) {
+    res.status(400).json({ msg: "Failed to update location" });
+  }
+})
+
 module.exports = router;

--- a/gohike-api/routes/user.js
+++ b/gohike-api/routes/user.js
@@ -143,9 +143,9 @@ router.get("/view/posts/:username", async (req, res) => {
   try {
     const username = req.params.username;
     // Gets post id's by calling User method
-    let posts = await User.getViewUserPosts(username);
+    let posts = await User.getUserPosts(username);
     res.status(201).json({ posts });
-  } catch {
+  } catch (err) {
     res.status(400).json({ msg: "Could not retrieve user posts." });
   }
 });

--- a/gohike-api/routes/user.js
+++ b/gohike-api/routes/user.js
@@ -64,7 +64,7 @@ router.get("/:sessionToken", async (req, res) => {
     // Gets user data by calling User method
     let userData = await User.getUserInfo(sessionToken);
     res.status(201).json({ user: userData });
-  } catch {
+  } catch (err) {
     res.status(400).json({ msg: "Could not retrieve user info." });
   }
 });
@@ -73,11 +73,11 @@ router.get("/:sessionToken", async (req, res) => {
  * Get request for getting the id's of posts made by the current user based on
  * their session token stored in local storage
  */
-router.get("/posts/:username", async (req, res) => {
+router.get("/posts/:sessionToken", async (req, res) => {
   try {
-    const username = req.params.username;
+    const sessionToken = req.params.sessionToken;
     // Gets current user's posts by calling User method
-    let posts = await User.getUserPosts(username);
+    let posts = await User.getUserPosts(sessionToken);
     res.status(201).json({ posts });
   } catch (err) {
     console.log(err);
@@ -143,7 +143,7 @@ router.get("/view/posts/:username", async (req, res) => {
   try {
     const username = req.params.username;
     // Gets post id's by calling User method
-    let posts = await User.getUserPosts(username);
+    let posts = await User.getViewUserPosts(username);
     res.status(201).json({ posts });
   } catch {
     res.status(400).json({ msg: "Could not retrieve user posts." });

--- a/gohike-ui/cypress/e2e/test/main.cy.js
+++ b/gohike-ui/cypress/e2e/test/main.cy.js
@@ -32,6 +32,7 @@ describe("Login", function () {
 
 describe("View Profile", function () {
   it("Navigate to personal profile", function () {
+    cy.wait(4000)
     // Navigate to personal profile
     cy.get("span")
       .contains("expand_more")
@@ -58,42 +59,10 @@ describe("View Profile", function () {
   });
 });
 
-describe("Feed", function () {
-  it("Navigate to feed page", function () {
-    // Navigate to feed page
-    cy.get("nav")
-      .contains("Feed")
-      .click()
-      .then((res) => {
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.eq("/feed");
-        });
-        cy.wait(5000)
-      });
-  });
-
-  it("Check feed elements", function () {
-    // Check basic elements of feed page
-    cy.wait(5000)
-    cy.get(".create-post-form").should("be.visible");
-    cy.get(".post-grid").should("be.visible");
-  });
-
-  it("Click on first post", function () {
-    // Click on trail name to navigate to find hikes page
-    cy.get(".post-trail")
-      .first()
-      .click()
-      .then((res) => {
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.include("/find-hikes");
-        });
-      });
-  });
-});
-
 describe("Find Hikes", function () {
   it("Search up a hike", function () {
+    // Navigate to find hikes page
+    cy.get(".nav-button").contains("Find Hikes").click();
     // Search up the Watchung hike
     cy.get(".hike-search-input").type("Watchung");
     cy.get(".hike-search-button")

--- a/gohike-ui/cypress/e2e/test/main.cy.js
+++ b/gohike-ui/cypress/e2e/test/main.cy.js
@@ -74,49 +74,29 @@ describe("Feed", function () {
   it("Check feed elements", function () {
     // Check basic elements of feed page
     cy.get(".create-post-form").should("be.visible");
-    // cy.get(".post-grid").should("be.visible");
   });
 
   it("Click on first post", function () {
     // Click on trail name to navigate to find hikes page
-    cy.get(".post-trail")
-      .first()
-      .click()
-      .then((res) => {
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.include("/find-hikes");
-        });
-      });
+    // cy.get(".post-trail", { timeout: 10000 })
+    //   .first()
+    //   .click()
+    //   .then((res) => {
+    //     cy.location().should((loc) => {
+    //       expect(loc.pathname).to.include("/find-hikes");
+    //     });
+    //   });
   });
 });
 
 describe("Find Hikes", function () {
   it("Search up a hike", function () {
-    // Search up the Watchung hike
-    cy.get(".hike-search-input").type("Watchung");
-    cy.get(".hike-search-button")
-      .click()
-      .then((res) => {
-        cy.wait(2000);
-        cy.get(".hike-card").first().contains("Watchung Reservation Loop");
-      });
-  });
+    // Navigate to find hikes page
+    // cy.visit("http://localhost:3000/find-hikes");
 
-  it("Get hike popout", function () {
-    // Click on the Watchung hike
-    cy.get(".hike-name")
-      .click()
-      .then((res) => {
-        cy.wait(2000);
-        cy.get(".hike-popout").should("be.visible");
-      });
-
-    // Close Watchung hike popout
-    cy.get(".close")
-      .click()
-      .then((res) => {
-        cy.get(".hike-popout").should("not.exist");
-      });
+    // Click on navigation in side bar to find hikes
+    // cy.get(".side-bar-saved-button")
+    //   .click()
   });
 });
 

--- a/gohike-ui/cypress/e2e/test/main.cy.js
+++ b/gohike-ui/cypress/e2e/test/main.cy.js
@@ -68,11 +68,13 @@ describe("Feed", function () {
         cy.location().should((loc) => {
           expect(loc.pathname).to.eq("/feed");
         });
+        cy.wait(5000)
       });
   });
 
   it("Check feed elements", function () {
     // Check basic elements of feed page
+    cy.wait(5000)
     cy.get(".create-post-form").should("be.visible");
     cy.get(".post-grid").should("be.visible");
   });

--- a/gohike-ui/cypress/e2e/test/main.cy.js
+++ b/gohike-ui/cypress/e2e/test/main.cy.js
@@ -74,29 +74,49 @@ describe("Feed", function () {
   it("Check feed elements", function () {
     // Check basic elements of feed page
     cy.get(".create-post-form").should("be.visible");
+    cy.get(".post-grid").should("be.visible");
   });
 
   it("Click on first post", function () {
     // Click on trail name to navigate to find hikes page
-    // cy.get(".post-trail", { timeout: 10000 })
-    //   .first()
-    //   .click()
-    //   .then((res) => {
-    //     cy.location().should((loc) => {
-    //       expect(loc.pathname).to.include("/find-hikes");
-    //     });
-    //   });
+    cy.get(".post-trail")
+      .first()
+      .click()
+      .then((res) => {
+        cy.location().should((loc) => {
+          expect(loc.pathname).to.include("/find-hikes");
+        });
+      });
   });
 });
 
 describe("Find Hikes", function () {
   it("Search up a hike", function () {
-    // Navigate to find hikes page
-    // cy.visit("http://localhost:3000/find-hikes");
+    // Search up the Watchung hike
+    cy.get(".hike-search-input").type("Watchung");
+    cy.get(".hike-search-button")
+      .click()
+      .then((res) => {
+        cy.wait(2000);
+        cy.get(".hike-card").first().contains("Watchung Reservation Loop");
+      });
+  });
 
-    // Click on navigation in side bar to find hikes
-    // cy.get(".side-bar-saved-button")
-    //   .click()
+  it("Get hike popout", function () {
+    // Click on the Watchung hike
+    cy.get(".hike-name")
+      .click()
+      .then((res) => {
+        cy.wait(2000);
+        cy.get(".hike-popout").should("be.visible");
+      });
+
+    // Close Watchung hike popout
+    cy.get(".close")
+      .click()
+      .then((res) => {
+        cy.get(".hike-popout").should("not.exist");
+      });
   });
 });
 

--- a/gohike-ui/cypress/e2e/test/main.cy.js
+++ b/gohike-ui/cypress/e2e/test/main.cy.js
@@ -22,6 +22,7 @@ describe("Login", function () {
     cy.get(".login-page-button")
       .click()
       .then((res) => {
+        cy.wait(10000)
         cy.location().should((loc) => {
           expect(loc.pathname).to.eq("/");
         });

--- a/gohike-ui/cypress/e2e/test/main.cy.js
+++ b/gohike-ui/cypress/e2e/test/main.cy.js
@@ -74,7 +74,7 @@ describe("Feed", function () {
   it("Check feed elements", function () {
     // Check basic elements of feed page
     cy.get(".create-post-form").should("be.visible");
-    cy.get(".post-grid").should("be.visible");
+    // cy.get(".post-grid").should("be.visible");
   });
 
   it("Click on first post", function () {

--- a/gohike-ui/src/components/App/App.jsx
+++ b/gohike-ui/src/components/App/App.jsx
@@ -48,23 +48,6 @@ export default function App() {
    * @type {boolean}
    */
   const [transparent, setTransparent] = React.useState(true);
-  /**
-   * State variable to help tell when to change navbar color
-   * @type {boolean}
-   */
-  const [color, setColor] = React.useState(false);
-  /**
-   * Function to trigger navbar to change color
-   */
-  const changeColor = () => {
-    if (window.scrollY >= 750) {
-      setColor(true);
-    } else {
-      setColor(false);
-    }
-  };
-
-  window.addEventListener("scroll", changeColor);
 
   // Return React component
   return (
@@ -73,7 +56,6 @@ export default function App() {
         <main>
           {/*Always shows Navbar*/}
           <Navbar
-            color={color}
             currUser={currUser}
             setCurrUser={setCurrUser}
             transparent={transparent}
@@ -84,6 +66,7 @@ export default function App() {
               path="/"
               element={
                 <Home
+                  currUser={currUser}
                   transparent={transparent}
                   setTransparent={setTransparent}
                 />

--- a/gohike-ui/src/components/Feed/Feed.css
+++ b/gohike-ui/src/components/Feed/Feed.css
@@ -97,6 +97,13 @@
     width: 65%;
 }
 
+.no-posts {
+    font-family: 'Gothic A1', sans-serif;
+    margin-top: 20px;
+    font-size: 16px;
+    color: #60270d;
+}
+
 /*Post Card*/
 .post-card {
     display: flex;

--- a/gohike-ui/src/components/Feed/Feed.jsx
+++ b/gohike-ui/src/components/Feed/Feed.jsx
@@ -128,7 +128,7 @@ export default function Feed({ transparent, setTransparent, currUser }) {
   React.useEffect(async () => {
     if (JSON.parse(localStorage.getItem("posts")) == null && posts == null) {
       setSpinner(true);
-      await sleep(4000).then(() => {
+      await sleep(10000).then(() => {
         setSpinner(false);
       });
     }

--- a/gohike-ui/src/components/Feed/Feed.jsx
+++ b/gohike-ui/src/components/Feed/Feed.jsx
@@ -87,13 +87,6 @@ export default function Feed({ transparent, setTransparent, currUser }) {
    * Fetches post data every time numPosts changes
    */
   React.useEffect(async () => {
-    if (JSON.parse(localStorage.getItem("posts")) == null && posts == null) {
-      setSpinner(true);
-      await sleep(4000).then(() => {
-        setSpinner(false);
-      });
-    }
-
     setPosts(JSON.parse(localStorage.getItem("posts")));
   }, [numPosts]);
 

--- a/gohike-ui/src/components/Feed/Feed.jsx
+++ b/gohike-ui/src/components/Feed/Feed.jsx
@@ -9,6 +9,7 @@ import { Link, useNavigate } from "react-router-dom";
 import axios from "axios";
 import Select from "react-select";
 import PostGrid from "./PostGrid";
+import { pq } from "../../../../gohike-api/models/pq";
 
 /**
  * Renders CreatePost and PostGrid component
@@ -67,7 +68,25 @@ export default function Feed({ transparent, setTransparent, currUser }) {
   async function fetchData() {
     let data = await axios.get(FRIENDS_POSTS_URL);
     setSpinner(true);
-    setPosts(data.data.posts);
+
+    // Only get hikes near user if location is available
+    if (navigator.geolocation) {
+      // Get user location
+      navigator.geolocation.getCurrentPosition(
+        async (position) => {
+          setPosts(pq.create(data.data.posts, position.coords.latitude, position.coords.longitude))
+        },
+        () => {
+          // Getting location fails
+          setPosts(data.data.posts);
+          setSpinner(false);
+        }
+      );
+    } else {
+      // Browser does not support geolocation
+      setPosts(data.data.posts);
+      setSpinner(false);
+    }
   }
 
   /**

--- a/gohike-ui/src/components/Feed/Feed.jsx
+++ b/gohike-ui/src/components/Feed/Feed.jsx
@@ -128,17 +128,13 @@ export default function Feed({ transparent, setTransparent, currUser }) {
   React.useEffect(async () => {
     if (JSON.parse(localStorage.getItem("posts")) == null && posts == null) {
       setSpinner(true);
-      await sleep(10000).then(() => {
+      await sleep(4000).then(() => {
         setSpinner(false);
       });
     }
 
     setPosts(JSON.parse(localStorage.getItem("posts")));
   }, [numPosts]);
-
-  if (posts == null) {
-    return null;
-  }
 
   // Return React component
   return (

--- a/gohike-ui/src/components/Feed/Feed.jsx
+++ b/gohike-ui/src/components/Feed/Feed.jsx
@@ -62,11 +62,11 @@ export default function Feed({ transparent, setTransparent, currUser }) {
    */
   const history = useNavigate();
 
-   /**
+  /**
    * Fetches post id's to render
    */
   async function fetchData() {
-    setSpinner(true)
+    setSpinner(true);
     let data = await axios.get(FRIENDS_POSTS_URL);
 
     // Only get hikes near user if location is available
@@ -84,18 +84,18 @@ export default function Feed({ transparent, setTransparent, currUser }) {
               )
             )
           );
-          setSpinner(false)
+          setSpinner(false);
         },
         () => {
           // Getting location fails
           localStorage.setItem("posts", JSON.stringify(data.data.posts));
-          setSpinner(false)
+          setSpinner(false);
         }
       );
     } else {
       // Browser does not support geolocation
       localStorage.setItem("posts", JSON.stringify(data.data.posts));
-      setSpinner(false)
+      setSpinner(false);
     }
   }
 
@@ -120,13 +120,13 @@ export default function Feed({ transparent, setTransparent, currUser }) {
    * Fetches post data every time numPosts changes
    */
   React.useEffect(async () => {
-    setSpinner(true)
+    setSpinner(true);
     if (JSON.parse(localStorage.getItem("posts")) == null) {
-      await fetchData()
+      await fetchData();
     }
-    
-    setPosts(JSON.parse(localStorage.getItem("posts")) )
-    setSpinner(false)
+
+    setPosts(JSON.parse(localStorage.getItem("posts")));
+    setSpinner(false);
   }, [numPosts]);
 
   // Return React component
@@ -134,7 +134,11 @@ export default function Feed({ transparent, setTransparent, currUser }) {
     <nav className="feed">
       <CreatePost trailsList={trailsList} currUser={currUser} />
       {!spinner ? (
-        <PostGrid posts={posts} currUser={currUser} />
+        posts != null ? (
+          <PostGrid posts={posts} currUser={currUser} />
+        ) : (
+          <LoadingScreen />
+        )
       ) : (
         <LoadingScreen />
       )}
@@ -206,8 +210,8 @@ export function CreatePost({ trailsList, currUser }) {
       base64String = "data:image/jpeg;base64," + base64String;
 
       // Get trail id
-      let trailId = trail.value
-      let captionValue = caption
+      let trailId = trail.value;
+      let captionValue = caption;
 
       // Resets form
       event.target[1].value = "";
@@ -222,7 +226,6 @@ export function CreatePost({ trailsList, currUser }) {
         sessionToken: currUser?.sessionToken,
         picture: base64String,
       });
-
     } catch {
       console.log("Failed to create post.");
     }
@@ -245,7 +248,7 @@ export function CreatePost({ trailsList, currUser }) {
           menuPosition="fixed"
           styles={{
             menuPortal: (provided) => ({ ...provided, zIndex: 9999 }),
-            menu: (provided) => ({ ...provided, zIndex: 9999 })
+            menu: (provided) => ({ ...provided, zIndex: 9999 }),
           }}
           options={trailsList}
           value={trail}

--- a/gohike-ui/src/components/Feed/Feed.jsx
+++ b/gohike-ui/src/components/Feed/Feed.jsx
@@ -62,42 +62,44 @@ export default function Feed({ transparent, setTransparent, currUser }) {
    */
   const history = useNavigate();
 
-  /**
-   * Fetches post id's to render
-   */
-  async function fetchData() {
-    setSpinner(true);
-    let data = await axios.get(FRIENDS_POSTS_URL);
+  // /**
+  //  * Fetches post id's to render
+  //  */
+  // async function fetchData() {
+  //   // setSpinner(true);
+  //   let data = await axios.get(FRIENDS_POSTS_URL);
 
-    // Only get hikes near user if location is available
-    if (navigator.geolocation) {
-      // Get user location
-      navigator.geolocation.getCurrentPosition(
-        async (position) => {
-          localStorage.setItem(
-            "posts",
-            JSON.stringify(
-              pq.create(
-                data.data.posts,
-                position.coords.latitude,
-                position.coords.longitude
-              )
-            )
-          );
-          setSpinner(false);
-        },
-        () => {
-          // Getting location fails
-          localStorage.setItem("posts", JSON.stringify(data.data.posts));
-          setSpinner(false);
-        }
-      );
-    } else {
-      // Browser does not support geolocation
-      localStorage.setItem("posts", JSON.stringify(data.data.posts));
-      setSpinner(false);
-    }
-  }
+  //   // Only get hikes near user if location is available
+  //   if (navigator.geolocation) {
+  //     console.log("hi")
+  //     // Get user location
+  //     navigator.geolocation.getCurrentPosition(
+  //       async (position) => {
+  //         localStorage.setItem(
+  //           "posts",
+  //           JSON.stringify(
+  //             pq.create(
+  //               data.data.posts,
+  //               position.coords.latitude,
+  //               position.coords.longitude
+  //             )
+  //           )
+  //         );
+  //         console.log("bye")
+  //         // setSpinner(false);
+  //       },
+  //       () => {
+  //         // Getting location fails
+  //         localStorage.setItem("posts", JSON.stringify(data.data.posts));
+  //         // setSpinner(false);
+  //       }
+  //     );
+  //   } else {
+  //     // Browser does not support geolocation
+  //     localStorage.setItem("posts", JSON.stringify(data.data.posts));
+  //     // setSpinner(false);
+  //   }
+  // }
 
   /**
    * Fetches data on the trails on every render
@@ -116,31 +118,36 @@ export default function Feed({ transparent, setTransparent, currUser }) {
     setTrailsList(data.data.trails);
   }, []);
 
+  const sleep = (milliseconds) => {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+  };
+
   /**
    * Fetches post data every time numPosts changes
    */
   React.useEffect(async () => {
-    setSpinner(true);
-    if (JSON.parse(localStorage.getItem("posts")) == null) {
-      await fetchData();
+    if (JSON.parse(localStorage.getItem("posts")) == null && posts == null) {
+      setSpinner(true);
+      await sleep(4000).then(() => {
+        setSpinner(false);
+      });
     }
 
     setPosts(JSON.parse(localStorage.getItem("posts")));
-    setSpinner(false);
   }, [numPosts]);
+
+  if (posts == null) {
+    return null;
+  }
 
   // Return React component
   return (
     <nav className="feed">
       <CreatePost trailsList={trailsList} currUser={currUser} />
-      {!spinner ? (
-        posts != null ? (
-          <PostGrid posts={posts} currUser={currUser} />
-        ) : (
-          <LoadingScreen />
-        )
-      ) : (
+      {spinner ? (
         <LoadingScreen />
+      ) : (
+        <PostGrid posts={posts} currUser={currUser} />
       )}
     </nav>
   );

--- a/gohike-ui/src/components/Feed/Feed.jsx
+++ b/gohike-ui/src/components/Feed/Feed.jsx
@@ -62,30 +62,40 @@ export default function Feed({ transparent, setTransparent, currUser }) {
    */
   const history = useNavigate();
 
-  /**
+   /**
    * Fetches post id's to render
    */
   async function fetchData() {
+    setSpinner(true)
     let data = await axios.get(FRIENDS_POSTS_URL);
-    setSpinner(true);
-    
+
     // Only get hikes near user if location is available
     if (navigator.geolocation) {
       // Get user location
       navigator.geolocation.getCurrentPosition(
         async (position) => {
-          setPosts(pq.create(data.data.posts, position.coords.latitude, position.coords.longitude))
+          localStorage.setItem(
+            "posts",
+            JSON.stringify(
+              pq.create(
+                data.data.posts,
+                position.coords.latitude,
+                position.coords.longitude
+              )
+            )
+          );
+          setSpinner(false)
         },
         () => {
           // Getting location fails
-          setPosts(data.data.posts);
-          setSpinner(false);
+          localStorage.setItem("posts", JSON.stringify(data.data.posts));
+          setSpinner(false)
         }
       );
     } else {
       // Browser does not support geolocation
-      setPosts(data.data.posts);
-      setSpinner(false);
+      localStorage.setItem("posts", JSON.stringify(data.data.posts));
+      setSpinner(false)
     }
   }
 
@@ -110,14 +120,20 @@ export default function Feed({ transparent, setTransparent, currUser }) {
    * Fetches post data every time numPosts changes
    */
   React.useEffect(async () => {
-    await fetchData();
+    setSpinner(true)
+    if (JSON.parse(localStorage.getItem("posts")) == null) {
+      await fetchData()
+    }
+    
+    setPosts(JSON.parse(localStorage.getItem("posts")) )
+    setSpinner(false)
   }, [numPosts]);
 
   // Return React component
   return (
     <nav className="feed">
       <CreatePost trailsList={trailsList} currUser={currUser} />
-      {spinner ? (
+      {!spinner ? (
         <PostGrid posts={posts} currUser={currUser} />
       ) : (
         <LoadingScreen />

--- a/gohike-ui/src/components/Feed/Feed.jsx
+++ b/gohike-ui/src/components/Feed/Feed.jsx
@@ -68,7 +68,7 @@ export default function Feed({ transparent, setTransparent, currUser }) {
   async function fetchData() {
     let data = await axios.get(FRIENDS_POSTS_URL);
     setSpinner(true);
-
+    
     // Only get hikes near user if location is available
     if (navigator.geolocation) {
       // Get user location

--- a/gohike-ui/src/components/Feed/Feed.jsx
+++ b/gohike-ui/src/components/Feed/Feed.jsx
@@ -29,7 +29,7 @@ export default function Feed({ transparent, setTransparent, currUser }) {
    * URL to get all posts in database
    * @type {string}
    */
-  const FRIENDS_POSTS_URL = `http://localhost:3001/posts/`;
+  const FRIENDS_POSTS_URL = `http://localhost:3001/posts/friends/${currUser?.username}`;
   /**
    * URL to get friends posts in database
    * @type {string}

--- a/gohike-ui/src/components/Feed/Feed.jsx
+++ b/gohike-ui/src/components/Feed/Feed.jsx
@@ -62,45 +62,6 @@ export default function Feed({ transparent, setTransparent, currUser }) {
    */
   const history = useNavigate();
 
-  // /**
-  //  * Fetches post id's to render
-  //  */
-  // async function fetchData() {
-  //   // setSpinner(true);
-  //   let data = await axios.get(FRIENDS_POSTS_URL);
-
-  //   // Only get hikes near user if location is available
-  //   if (navigator.geolocation) {
-  //     console.log("hi")
-  //     // Get user location
-  //     navigator.geolocation.getCurrentPosition(
-  //       async (position) => {
-  //         localStorage.setItem(
-  //           "posts",
-  //           JSON.stringify(
-  //             pq.create(
-  //               data.data.posts,
-  //               position.coords.latitude,
-  //               position.coords.longitude
-  //             )
-  //           )
-  //         );
-  //         console.log("bye")
-  //         // setSpinner(false);
-  //       },
-  //       () => {
-  //         // Getting location fails
-  //         localStorage.setItem("posts", JSON.stringify(data.data.posts));
-  //         // setSpinner(false);
-  //       }
-  //     );
-  //   } else {
-  //     // Browser does not support geolocation
-  //     localStorage.setItem("posts", JSON.stringify(data.data.posts));
-  //     // setSpinner(false);
-  //   }
-  // }
-
   /**
    * Fetches data on the trails on every render
    */

--- a/gohike-ui/src/components/Feed/Feed.jsx
+++ b/gohike-ui/src/components/Feed/Feed.jsx
@@ -29,7 +29,7 @@ export default function Feed({ transparent, setTransparent, currUser }) {
    * URL to get all posts in database
    * @type {string}
    */
-  const FRIENDS_POSTS_URL = `http://localhost:3001/posts/friends/${currUser.sessionToken}`;
+  const FRIENDS_POSTS_URL = `http://localhost:3001/posts/`;
   /**
    * URL to get friends posts in database
    * @type {string}
@@ -169,19 +169,25 @@ export function CreatePost({ trailsList, currUser }) {
       // Convert the array to a base64 string
       let base64String = _arrayBufferToBase64(arrayBuffer);
       base64String = "data:image/jpeg;base64," + base64String;
-      // Upload to Parse
-      await axios.post(CREATE_POST_URL, {
-        hikeId: trail.value,
-        caption,
-        sessionToken: currUser?.sessionToken,
-        picture: base64String,
-      });
+
+      // Get trail id
+      let trailId = trail.value
+      let captionValue = caption
 
       // Resets form
       event.target[1].value = "";
       setPicture(null);
       setTrail("");
       setCaption("");
+
+      // Upload to Parse
+      let post = await axios.post(CREATE_POST_URL, {
+        hikeId: trailId,
+        caption: captionValue,
+        sessionToken: currUser?.sessionToken,
+        picture: base64String,
+      });
+
     } catch {
       console.log("Failed to create post.");
     }
@@ -200,6 +206,12 @@ export function CreatePost({ trailsList, currUser }) {
       />
       <div className="add-to-post">
         <Select
+          menuPortalTarget={document.body}
+          menuPosition="fixed"
+          styles={{
+            menuPortal: (provided) => ({ ...provided, zIndex: 9999 }),
+            menu: (provided) => ({ ...provided, zIndex: 9999 })
+          }}
           options={trailsList}
           value={trail}
           placeholder="Select Trail"

--- a/gohike-ui/src/components/Feed/PostGrid.jsx
+++ b/gohike-ui/src/components/Feed/PostGrid.jsx
@@ -26,7 +26,7 @@ export default function PostGrid({ posts, currUser }) {
   return (
     <div className="post-grid">
       {posts.length == 0
-        ? "No posts to display"
+        ? <div className="no-posts">No posts to display</div>
         : posts.map((postObj, index) => {
             /**
              * URL for put request to like a post

--- a/gohike-ui/src/components/Feed/PostGrid.jsx
+++ b/gohike-ui/src/components/Feed/PostGrid.jsx
@@ -70,9 +70,7 @@ export default function PostGrid({ posts, currUser }) {
                 postId: postObj.id,
               });
 
-              let data = await axios.get(GET_POST_URL, {
-                sessionToken: currUser.sessionToken,
-              });
+              let data = await axios.get(GET_POST_URL);
               setLikes(data.data.post.likes);
               setLiked(true);
             }

--- a/gohike-ui/src/components/Feed/PostGrid.jsx
+++ b/gohike-ui/src/components/Feed/PostGrid.jsx
@@ -27,7 +27,7 @@ export default function PostGrid({ posts, currUser }) {
     <div className="post-grid">
       {posts.length == 0
         ? "No posts to display"
-        : posts.map((postId, index) => {
+        : posts.map((postObj, index) => {
             /**
              * URL for put request to like a post
              * @type {string}
@@ -42,7 +42,7 @@ export default function PostGrid({ posts, currUser }) {
              * URL for get request to get info on a post
              * @type {string}
              */
-            const GET_POST_URL = `http://localhost:3001/posts/${postId}`;
+            const GET_POST_URL = `http://localhost:3001/posts/${postObj.id}`;
             /**
              * Holds info on post corresponding to postId
              * @type {{ username: string, trailName: string, hikeId:
@@ -67,7 +67,7 @@ export default function PostGrid({ posts, currUser }) {
             async function likePost() {
               await axios.put(LIKE_URL, {
                 username: currUser.username,
-                postId,
+                postId: postObj.id,
               });
 
               let data = await axios.get(GET_POST_URL, {

--- a/gohike-ui/src/components/Home/Home.jsx
+++ b/gohike-ui/src/components/Home/Home.jsx
@@ -41,6 +41,39 @@ export default function Home({ currUser, transparent, setTransparent }) {
   }
 
   /**
+   * Fetches post id's to render
+   */
+  async function fetchData() {
+    let data = await axios.get(FRIENDS_POSTS_URL);
+
+    // Only get hikes near user if location is available
+    if (navigator.geolocation) {
+      // Get user location
+      navigator.geolocation.getCurrentPosition(
+        async (position) => {
+          localStorage.setItem(
+            "posts",
+            JSON.stringify(
+              pq.create(
+                data.data.posts,
+                position.coords.latitude,
+                position.coords.longitude
+              )
+            )
+          );
+        },
+        () => {
+          // Getting location fails
+          localStorage.setItem("posts", JSON.stringify(data.data.posts));
+        }
+      );
+    } else {
+      // Browser does not support geolocation
+      localStorage.setItem("posts", JSON.stringify(data.data.posts));
+    }
+  }
+
+  /**
    * Makes animated components visible on render
    */
   React.useEffect(async () => {

--- a/gohike-ui/src/components/Home/Home.jsx
+++ b/gohike-ui/src/components/Home/Home.jsx
@@ -13,15 +13,22 @@ import "./Home.css";
 import Plx from "react-plx";
 import axios from "axios";
 import { Link } from "react-router-dom";
+import { pq } from "../../../../gohike-api/models/pq";
 
 /**
  * Renders Home page with animations and on scroll effects
  *
+ * @param {{username: string, sessionToken: string}} currUser Current user info
  * @param {boolean} transparent State var holding state of Navbar background
  * @param {function} setTransparent Sets the boolean in transparent
  * @returns Home component
  */
-export default function Home({ transparent, setTransparent }) {
+export default function Home({ currUser, transparent, setTransparent }) {
+  /**
+   * URL to get all posts in database
+   * @type {string}
+   */
+  const FRIENDS_POSTS_URL = `http://localhost:3001/posts/friends/${currUser?.username}`;
   /**
    * Animation helper
    */
@@ -34,12 +41,50 @@ export default function Home({ transparent, setTransparent }) {
   }
 
   /**
+   * Fetches post id's to render
+   */
+  async function fetchData() {
+    let data = await axios.get(FRIENDS_POSTS_URL);
+
+    // Only get hikes near user if location is available
+    if (navigator.geolocation) {
+      // Get user location
+      navigator.geolocation.getCurrentPosition(
+        async (position) => {
+          localStorage.setItem(
+            "posts",
+            JSON.stringify(
+              pq.create(
+                data.data.posts,
+                position.coords.latitude,
+                position.coords.longitude
+              )
+            )
+          );
+        },
+        () => {
+          // Getting location fails
+          localStorage.setItem("posts", JSON.stringify(data.data.posts));
+        }
+      );
+    } else {
+      // Browser does not support geolocation
+      localStorage.setItem("posts", JSON.stringify(data.data.posts));
+    }
+  }
+
+  /**
    * Makes animated components visible on render
    */
-  React.useEffect(() => {
+  React.useEffect(async () => {
     makeVisible();
     if (!transparent) {
       setTransparent(true);
+    }
+
+    // Prefetch and set posts in local storage if not already set
+    if (currUser != null && JSON.parse(localStorage.getItem("posts")) == null) {
+      await fetchData();
     }
   }, []);
 

--- a/gohike-ui/src/components/Home/Home.jsx
+++ b/gohike-ui/src/components/Home/Home.jsx
@@ -41,50 +41,12 @@ export default function Home({ currUser, transparent, setTransparent }) {
   }
 
   /**
-   * Fetches post id's to render
-   */
-  async function fetchData() {
-    let data = await axios.get(FRIENDS_POSTS_URL);
-
-    // Only get hikes near user if location is available
-    if (navigator.geolocation) {
-      // Get user location
-      navigator.geolocation.getCurrentPosition(
-        async (position) => {
-          localStorage.setItem(
-            "posts",
-            JSON.stringify(
-              pq.create(
-                data.data.posts,
-                position.coords.latitude,
-                position.coords.longitude
-              )
-            )
-          );
-        },
-        () => {
-          // Getting location fails
-          localStorage.setItem("posts", JSON.stringify(data.data.posts));
-        }
-      );
-    } else {
-      // Browser does not support geolocation
-      localStorage.setItem("posts", JSON.stringify(data.data.posts));
-    }
-  }
-
-  /**
    * Makes animated components visible on render
    */
   React.useEffect(async () => {
     makeVisible();
     if (!transparent) {
       setTransparent(true);
-    }
-
-    // Prefetch and set posts in local storage if not already set
-    if (currUser != null && JSON.parse(localStorage.getItem("posts")) == null) {
-      await fetchData();
     }
   }, []);
 

--- a/gohike-ui/src/components/Login/Login.jsx
+++ b/gohike-ui/src/components/Login/Login.jsx
@@ -33,6 +33,11 @@ export default function Login({ setCurrUser, transparent, setTransparent }) {
    */
   const [password, setPassword] = React.useState("");
   /**
+   * Spinner for loading state
+   * @type {boolean}
+   */
+  const [spinner, setSpinner] = React.useState(false);
+  /**
    * Holds error message
    * @type {string}
    */
@@ -72,6 +77,7 @@ export default function Login({ setCurrUser, transparent, setTransparent }) {
    */
   const handleSubmit = async (event) => {
     event.preventDefault();
+    setSpinner(true)
 
     // Only get hikes near user if location is available
     if (navigator.geolocation) {
@@ -92,8 +98,10 @@ export default function Login({ setCurrUser, transparent, setTransparent }) {
               // Update feed and location if location has changed since last time
               // Set local storage
               if (
-                loginUser.data.location.lat - position.coords.latitude > 1 || loginUser.data.location.lat - position.coords.latitude < -1  ||
-                loginUser.data.location.lng - position.coords.longitude > 1 || loginUser.data.location.lng - position.coords.longitude < -1
+                loginUser.data.location.lat - position.coords.latitude > 1 ||
+                loginUser.data.location.lat - position.coords.latitude < -1 ||
+                loginUser.data.location.lng - position.coords.longitude > 1 ||
+                loginUser.data.location.lng - position.coords.longitude < -1
               ) {
                 // Update feed and location
                 await axios
@@ -144,6 +152,7 @@ export default function Login({ setCurrUser, transparent, setTransparent }) {
               }
 
               // Reset login form
+              setSpinner(false)
               setUsername("");
               setPassword("");
               history("/");
@@ -155,34 +164,31 @@ export default function Login({ setCurrUser, transparent, setTransparent }) {
         },
         async () => {
           // Getting location fails
-          // Can still login but cannot 
+          // Can still login but cannot get location
           await axios
-          .post(LOGIN_URL, { username, password })
-          .then(async (loginUser) => {
-            setCurrUser({
-              username: loginUser.data.username,
-              sessionToken: loginUser.data.sessionToken,
-              firstName: loginUser.data.firstName,
-              lastName: loginUser.data.lastName,
-            });
+            .post(LOGIN_URL, { username, password })
+            .then(async (loginUser) => {
+              setCurrUser({
+                username: loginUser.data.username,
+                sessionToken: loginUser.data.sessionToken,
+                firstName: loginUser.data.firstName,
+                lastName: loginUser.data.lastName,
+              });
 
-            // Set cache
-            localStorage.setItem("username", loginUser.data.username);
-            localStorage.setItem(
-              "sessionToken",
-              loginUser.data.sessionToken
-            );
-            localStorage.setItem("firstName", loginUser.data.firstName);
-            localStorage.setItem("lastName", loginUser.data.lastName);
-            localStorage.setItem(
-              "posts",
-              JSON.stringify(loginUser.data.posts)
-            );
-            localStorage.setItem(
-              "location",
-              JSON.stringify(loginUser.data.location)
-            );
-          });
+              // Set cache
+              localStorage.setItem("username", loginUser.data.username);
+              localStorage.setItem("sessionToken", loginUser.data.sessionToken);
+              localStorage.setItem("firstName", loginUser.data.firstName);
+              localStorage.setItem("lastName", loginUser.data.lastName);
+              localStorage.setItem(
+                "posts",
+                JSON.stringify(loginUser.data.posts)
+              );
+              localStorage.setItem(
+                "location",
+                JSON.stringify(loginUser.data.location)
+              );
+            });
 
           // Reset login form
           setUsername("");
@@ -192,7 +198,7 @@ export default function Login({ setCurrUser, transparent, setTransparent }) {
       );
     } else {
       // Browser does not support geolocation
-      alert("Please allow access to current location before logging in")
+      alert("Please allow access to current location before logging in");
     }
   };
 
@@ -234,7 +240,11 @@ export default function Login({ setCurrUser, transparent, setTransparent }) {
             placeholder="Password"
             required
           />
-          <button className="login-page-button">Log In</button>
+          {spinner ? (
+            <button className="login-page-button">Preparing your account!</button>
+          ) : (
+            <button className="login-page-button">Log In</button>
+          )}
         </form>
         <div className="need-account">
           <p>Need an account?</p>

--- a/gohike-ui/src/components/Login/Login.jsx
+++ b/gohike-ui/src/components/Login/Login.jsx
@@ -153,13 +153,46 @@ export default function Login({ setCurrUser, transparent, setTransparent }) {
               errorRef.current.focus();
             });
         },
-        () => {
+        async () => {
           // Getting location fails
-          alert("Please allow access to current location before logging in")
+          // Can still login but cannot 
+          await axios
+          .post(LOGIN_URL, { username, password })
+          .then(async (loginUser) => {
+            setCurrUser({
+              username: loginUser.data.username,
+              sessionToken: loginUser.data.sessionToken,
+              firstName: loginUser.data.firstName,
+              lastName: loginUser.data.lastName,
+            });
+
+            // Set cache
+            localStorage.setItem("username", loginUser.data.username);
+            localStorage.setItem(
+              "sessionToken",
+              loginUser.data.sessionToken
+            );
+            localStorage.setItem("firstName", loginUser.data.firstName);
+            localStorage.setItem("lastName", loginUser.data.lastName);
+            localStorage.setItem(
+              "posts",
+              JSON.stringify(loginUser.data.posts)
+            );
+            localStorage.setItem(
+              "location",
+              JSON.stringify(loginUser.data.location)
+            );
+          });
+
+          // Reset login form
+          setUsername("");
+          setPassword("");
+          history("/");
         }
       );
     } else {
       // Browser does not support geolocation
+      alert("Please allow access to current location before logging in")
     }
   };
 

--- a/gohike-ui/src/components/Login/Login.jsx
+++ b/gohike-ui/src/components/Login/Login.jsx
@@ -80,62 +80,86 @@ export default function Login({ setCurrUser, transparent, setTransparent }) {
         async (position) => {
           // Login user by making post request
           await axios
-          .post(LOGIN_URL, { username, password })
-          .then(function (loginUser) {
-            setCurrUser({
-              username: loginUser.data.username,
-              sessionToken: loginUser.data.sessionToken,
-              firstName: loginUser.data.firstName,
-              lastName: loginUser.data.lastName,
+            .post(LOGIN_URL, { username, password })
+            .then(async (loginUser) => {
+              setCurrUser({
+                username: loginUser.data.username,
+                sessionToken: loginUser.data.sessionToken,
+                firstName: loginUser.data.firstName,
+                lastName: loginUser.data.lastName,
+              });
+
+              // Update feed and location if location has changed since last time
+              // Set local storage
+              if (
+                loginUser.data.location.lat - position.coords.latitude > 1 || loginUser.data.location.lat - position.coords.latitude < -1  ||
+                loginUser.data.location.lng - position.coords.longitude > 1 || loginUser.data.location.lng - position.coords.longitude < -1
+              ) {
+                // Update feed and location
+                await axios
+                  .put("http://localhost:3001/user/update-location", {
+                    lat: position.coords.latitude,
+                    lng: position.coords.longitude,
+                    username: loginUser.data.username,
+                  })
+                  .then((data) => {
+                    // Set cache
+                    localStorage.setItem("username", loginUser.data.username);
+                    localStorage.setItem(
+                      "sessionToken",
+                      loginUser.data.sessionToken
+                    );
+                    localStorage.setItem("firstName", loginUser.data.firstName);
+                    localStorage.setItem("lastName", loginUser.data.lastName);
+
+                    // Set feed/location cache
+                    localStorage.setItem(
+                      "posts",
+                      JSON.stringify(data.data.posts)
+                    );
+                    localStorage.setItem(
+                      "location",
+                      JSON.stringify(data.data.location)
+                    );
+                  });
+              }
+              // Otherwise just set local storage
+              else {
+                // Set cache
+                localStorage.setItem("username", loginUser.data.username);
+                localStorage.setItem(
+                  "sessionToken",
+                  loginUser.data.sessionToken
+                );
+                localStorage.setItem("firstName", loginUser.data.firstName);
+                localStorage.setItem("lastName", loginUser.data.lastName);
+                localStorage.setItem(
+                  "posts",
+                  JSON.stringify(loginUser.data.posts)
+                );
+                localStorage.setItem(
+                  "location",
+                  JSON.stringify(loginUser.data.location)
+                );
+              }
+
+              // Reset login form
+              setUsername("");
+              setPassword("");
+              history("/");
+            })
+            .catch((err) => {
+              setError("Invalid Username or Password");
+              errorRef.current.focus();
             });
-
-            // Update feed and location if location has changed since last time
-            // Set local storage
-            if (loginUser.data.location.lat != position.coords.latitude || 
-              loginUser.data.location.lng != position.coords.longitude) {
-              // Update feed and location
-              await axios.put("http://localhost:3001/user/update-location", { 
-                lat: position.coords.latitude, 
-                lng: position.coords.longitude, username: loginUser.data.username })
-                .then((data) => {
-                  // Set cache
-                  localStorage.setItem("username", loginUser.data.username);
-                  localStorage.setItem("sessionToken", loginUser.data.sessionToken);
-                  localStorage.setItem("firstName", loginUser.data.firstName);
-                  localStorage.setItem("lastName", loginUser.data.lastName);
-                  localStorage.setItem("posts", JSON.stringify(data.data.posts));
-                  localStorage.setItem("location", JSON.stringify(data.data.location));
-                })
-            }
-            // Otherwise just set local storage
-            else {
-              // Set cache
-              localStorage.setItem("username", loginUser.data.username);
-              localStorage.setItem("sessionToken", loginUser.data.sessionToken);
-              localStorage.setItem("firstName", loginUser.data.firstName);
-              localStorage.setItem("lastName", loginUser.data.lastName);
-              localStorage.setItem("posts", JSON.stringify(loginUser.data.posts));
-              localStorage.setItem("location", JSON.stringify(loginUser.data.location));
-            }
-
-            // Reset login form
-            setUsername("");
-            setPassword("");
-            history("/");
-          })
-          .catch((err) => {
-            setError("Invalid Username or Password");
-            errorRef.current.focus();
-          });
         },
         () => {
           // Getting location fails
-          
+          alert("Please allow access to current location before logging in")
         }
       );
     } else {
       // Browser does not support geolocation
-      
     }
   };
 

--- a/gohike-ui/src/components/MyProfile/MyProfile.jsx
+++ b/gohike-ui/src/components/MyProfile/MyProfile.jsx
@@ -143,7 +143,7 @@ export default function MyProfile({ transparent, setTransparent, currUser }) {
     setProfileData(data.data.user);
 
     let data2 = await axios.get(
-      `http://localhost:3001/user/posts/${currUser.sessionToken}`
+      `http://localhost:3001/user/posts/${currUser.username}`
     );
     setPosts(data2.data.posts);
   };

--- a/gohike-ui/src/components/Navbar/Navbar.jsx
+++ b/gohike-ui/src/components/Navbar/Navbar.jsx
@@ -39,9 +39,7 @@ export default function Navbar({ currUser, setCurrUser, transparent }) {
 
   // Return React component
   return (
-    <nav
-      className={`navbar ${transparent ? "transparent" : ""}`}
-    >
+    <nav className={`navbar ${transparent ? "transparent" : ""}`}>
       <Logo className="nav-logo" />
       <button
         className="nav-button"
@@ -167,7 +165,10 @@ export function Dropdown({
   const handleLogout = async () => {
     history("/");
     axios
-      .post(LOGOUT_URL, { sessionToken: currUser.sessionToken })
+      .post(LOGOUT_URL, {
+        sessionToken: currUser.sessionToken,
+        feed: JSON.parse(localStorage.getItem("posts")),
+      })
       .then((results) => {
         setCurrUser(null);
         localStorage.clear();
@@ -236,19 +237,19 @@ export function FriendRequests({ friendsOpen, currUser }) {
    * Fetches friend request data on every render
    */
   React.useEffect(async () => {
-      let data = await axios.get(
-        `http://localhost:3001/user/${currUser?.sessionToken}`
-      );
+    let data = await axios.get(
+      `http://localhost:3001/user/${currUser?.sessionToken}`
+    );
 
-      if (
-        data.data.user.incomingFriendRequests == null ||
-        data.data.user.incomingFriendRequests == undefined ||
-        data.data.user.incomingFriendRequests.length == 0
-      ) {
-        setFriendRequests([]);
-      } else {
-        setFriendRequests(data.data.user.incomingFriendRequests);
-      }
+    if (
+      data.data.user.incomingFriendRequests == null ||
+      data.data.user.incomingFriendRequests == undefined ||
+      data.data.user.incomingFriendRequests.length == 0
+    ) {
+      setFriendRequests([]);
+    } else {
+      setFriendRequests(data.data.user.incomingFriendRequests);
+    }
   }, []);
 
   // Don't return until friend requests data is set

--- a/gohike-ui/src/components/Navbar/Navbar.jsx
+++ b/gohike-ui/src/components/Navbar/Navbar.jsx
@@ -20,7 +20,7 @@ import { useLocation, useNavigate } from "react-router-dom";
  * @param {boolean} transparent Hold the state of the Navbar background
  * @returns Navbar component
  */
-export default function Navbar({ color, currUser, setCurrUser, transparent }) {
+export default function Navbar({ currUser, setCurrUser, transparent }) {
   /**
    * State of the dropdown visibility when logged in
    * @type {boolean}
@@ -40,8 +40,7 @@ export default function Navbar({ color, currUser, setCurrUser, transparent }) {
   // Return React component
   return (
     <nav
-      className={`navbar ${transparent ? "transparent" : ""} 
-      ${color ? (useLocation().pathname == "/" ? "color" : "") : ""}`}
+      className={`navbar ${transparent ? "transparent" : ""}`}
     >
       <Logo className="nav-logo" />
       <button
@@ -237,19 +236,19 @@ export function FriendRequests({ friendsOpen, currUser }) {
    * Fetches friend request data on every render
    */
   React.useEffect(async () => {
-    let data = await axios.get(
-      `http://localhost:3001/user/${currUser.sessionToken}`
-    );
+      let data = await axios.get(
+        `http://localhost:3001/user/${currUser?.sessionToken}`
+      );
 
-    if (
-      data.data.user.incomingFriendRequests == null ||
-      data.data.user.incomingFriendRequests == undefined ||
-      data.data.user.incomingFriendRequests.length == 0
-    ) {
-      setFriendRequests([]);
-    } else {
-      setFriendRequests(data.data.user.incomingFriendRequests);
-    }
+      if (
+        data.data.user.incomingFriendRequests == null ||
+        data.data.user.incomingFriendRequests == undefined ||
+        data.data.user.incomingFriendRequests.length == 0
+      ) {
+        setFriendRequests([]);
+      } else {
+        setFriendRequests(data.data.user.incomingFriendRequests);
+      }
   }, []);
 
   // Don't return until friend requests data is set

--- a/gohike-ui/src/components/ViewProfile/ViewProfile.css
+++ b/gohike-ui/src/components/ViewProfile/ViewProfile.css
@@ -97,7 +97,7 @@
   border-radius: 2px;
   padding-top: 5px;
   width: 150px;
-  margin-left: 84%;
+  margin-left: 80%;
   font-size: 12px;
   margin-bottom: -20px;
   z-index: 10;


### PR DESCRIPTION
**Description**

- Speeds up the time it takes to fetch post id's of posts to render for feed page by using a fan out on write method that writes a post id to the feeds of every user who is a friend of the post creator at the time of post creation. This way we do not have to sort through all posts in the Parse database to fetch a user's feed
- Before, a user's feed was sorted by creation date (recently created posts appear at top of feed). I have made feed sorted by distance from user (posts created about hikes close to the user will appear at top of feed). I implemented an algorithm that creates a priority queue to store post id's for a user's feed with higher priority given to hikes with a smaller distance from a user. This priority queue is prefetched upon user login so that feed page is readily available when a user navigates to their feed page. 
- Right now, a priority queue is re-sorted everytime a user logs in. In future PR's, upon user logout, this array based priority queue as well as the user's most recent geolocation will be stored in Parse. Upon the next user login, we will only have to re-sort the priority queue if a user's location has changed greatly since last login.

**Milestone**
- This contributes to my stretch feature of speeding up render time for a user's feed

**Test Plan**

- Time to fetch post id's for a user's feed has decreased significantly and keeps more of a constant time relative to the amount of friends a user has:


<img width="1186" alt="Screen Shot 2022-07-27 at 11 39 31 AM" src="https://user-images.githubusercontent.com/86620096/181347762-cf3d8ef5-8c7d-4a0c-ab6c-ae9d2774a23e.png">

- In addition to faster fetches, user's feeds are loaded almost instantaneously upon click since data is prefetched on login:


https://user-images.githubusercontent.com/86620096/181392738-62a650d9-5813-4e67-8327-4faef7506aad.mp4


**Next Step**
- Implement live feed (hopefully get to that tomorrow and if not, Friday)


